### PR TITLE
fix: clear messageWithPing on every guild

### DIFF
--- a/src/utils/messaging.ts
+++ b/src/utils/messaging.ts
@@ -85,7 +85,7 @@ export const deliverContentToAll = (
   }
 
   let channel;
-  const messageWithPing = { ...message };
+  let messageWithPing;
   client.guilds.cache.forEach((guild) => {
     stats.server.count++;
     stats.server.members += guild.memberCount;
@@ -105,6 +105,7 @@ export const deliverContentToAll = (
     stats.server.withChannel.members += guild.memberCount;
 
     const role = guild.roles.cache.find((role) => role.name === "hltv");
+    messageWithPing = { ...message };
 
     if (role) {
       messageWithPing.content = `${message.content} <@&${role.id}>`;


### PR DESCRIPTION
current setup will try to attach the role from a previous server if the current server has no role:

`Short news: Week 29  https://www.hltv.org/news/45162/short-news-week-29 @unknown-role`

minor but looks bad