### PR TITLE
refactor(rss): wait on rss check properly

### DIFF
--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -16,7 +16,12 @@ export default async function ready(client: Client) {
   setInterval(updateActivity, 60e3, client);
 
   for (;;) {
-    rssChecker("hltv", "https://www.hltv.org/rss/news", client);
+    try {
+      await rssChecker("hltv", "https://www.hltv.org/rss/news", client);
+    } catch (error) {
+      logger.error(logger.error(`Error processing RSS feed:`, error));
+    }
+
     await sleep(5e3);
   }
 }

--- a/src/utils/messaging.ts
+++ b/src/utils/messaging.ts
@@ -85,7 +85,6 @@ export const deliverContentToAll = (
   }
 
   let channel;
-  let messageWithPing;
   client.guilds.cache.forEach((guild) => {
     stats.server.count++;
     stats.server.members += guild.memberCount;
@@ -105,16 +104,19 @@ export const deliverContentToAll = (
     stats.server.withChannel.members += guild.memberCount;
 
     const role = guild.roles.cache.find((role) => role.name === "hltv");
-    messageWithPing = { ...message };
+    let messageWithPing;
 
     if (role) {
-      messageWithPing.content = `${message.content} <@&${role.id}>`;
+      messageWithPing = {
+        ...message,
+        content: `${message.content} <@&${role.id}>`,
+      };
       stats.server.withChannel.withRole.count++;
       stats.server.withChannel.withRole.members += guild.memberCount;
     }
 
     let errored: boolean;
-    deliverContent(channel, name, messageWithPing)
+    deliverContent(channel, name, messageWithPing ?? message)
       .catch((error: Error) => {
         errored = true;
 

--- a/src/utils/rss.ts
+++ b/src/utils/rss.ts
@@ -1,19 +1,16 @@
 import { Client } from "discord.js";
 import { readFileSync, writeFileSync } from "fs";
 import { join } from "path";
-import Parser, { Output } from "rss-parser";
-
-import { HltvArticle } from "../events/newArticle.js";
-import { logger } from "./logging";
+import Parser from "rss-parser";
 
 const rss = new Parser({
   customFields: {
     item: ["pubDate", ["media:content", "media", { keepArray: false }]],
   },
-  timeout: 5000,
+  timeout: 4e3,
 });
 
-export function rssChecker(name: string, url: string, client: Client) {
+export async function rssChecker(name: string, url: string, client: Client) {
   const articleStorageFileLocation = join(
     __dirname,
     "..",
@@ -22,29 +19,23 @@ export function rssChecker(name: string, url: string, client: Client) {
     `current_${name}_article.json`,
   );
 
-  rss.parseURL(url, function (error: Error, feed: Output<HltvArticle>) {
-    if (error) {
-      logger.error(`Error processing RSS feed ${url}:`, error);
-      return;
-    }
+  const feed = await rss.parseURL(url);
+  const newestArticle = feed.items[0];
 
-    const newestArticle = feed.items[0];
+  const file = readFileSync(articleStorageFileLocation);
+  const currentArticle = JSON.parse(file.toString());
 
-    const file = readFileSync(articleStorageFileLocation);
-    const currentArticle = JSON.parse(file.toString());
+  const currentArticleDate = new Date(currentArticle.pubDate);
+  const newestArticleDate = new Date(newestArticle.pubDate);
+  const isStale = newestArticleDate < currentArticleDate;
 
-    const currentArticleDate = new Date(currentArticle.pubDate);
-    const newestArticleDate = new Date(newestArticle.pubDate);
-    const isStale = newestArticleDate < currentArticleDate;
-
-    if (
-      currentArticle.guid &&
-      newestArticle.guid !== currentArticle.guid &&
-      !isStale
-    ) {
-      const data = JSON.stringify(newestArticle);
-      writeFileSync(articleStorageFileLocation, data);
-      client.emit("newArticle", newestArticle);
-    }
-  });
+  if (
+    currentArticle.guid &&
+    newestArticle.guid !== currentArticle.guid &&
+    !isStale
+  ) {
+    const data = JSON.stringify(newestArticle);
+    writeFileSync(articleStorageFileLocation, data);
+    client.emit("newArticle", newestArticle);
+  }
 }


### PR DESCRIPTION
await the rss feed properly

desync the rss-related timings so the next request does not start immediately upon the timeout of the previous one

also make the message with ping memory overhead a little lower by avoiding copying the entire message (inc embeds)