### PR TITLE
feat(message): add read button to article

### DIFF
--- a/src/events/newArticle.ts
+++ b/src/events/newArticle.ts
@@ -1,4 +1,5 @@
 import { Client } from "discord.js";
+import { ButtonStyle } from "discord-api-types/v9";
 import { Item } from "rss-parser";
 
 import { logger } from "../utils/logging.js";
@@ -34,11 +35,24 @@ export default function newArticle(client: Client, article: HltvArticle) {
           url: article.media.$.url,
         },
         footer: {
-          text: "HLTV.org - The home of competitive Counter-Strike",
+          text: "HLTV.org",
           icon_url:
             "https://www.hltv.org/img/static/favicon/apple-touch-icon.png",
         },
         timestamp: article.isoDate,
+      },
+    ],
+    components: [
+      {
+        type: 1,
+        components: [
+          {
+            type: 2,
+            style: ButtonStyle.Link,
+            label: "Read",
+            url: article.link,
+          },
+        ],
       },
     ],
   };


### PR DESCRIPTION
added a link button to open the article at the bottom of the message - for anyone who doesn't want to or think you can click the embed title

removed the hltv slogan since it wrapped on mobile - bit crowded with the button